### PR TITLE
add type info and mapper name to tcplay entries in "/dev/disk/by-id/"

### DIFF
--- a/tcplay.c
+++ b/tcplay.c
@@ -464,7 +464,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 	else {
 		veracrypt_mode = 0;
 	}
-	
+
 	if (((TC_FLAG_SET(flags, SYS)) || (TC_FLAG_SET(flags, FDE))) && !hidden_header) {
 		// use only PRF with iterations count for boot encryption
 		// except in case of hidden operating system which uses normal iterations count
@@ -474,7 +474,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 		// use only PRF with iterations count for standard encryption
 		pbkdf_prf_algos = veracrypt_mode? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 	}
-	
+
 	/* Start search for correct algorithm combination */
 	found = 0;
 	for (i = 0; !found && pbkdf_prf_algos[i].name != NULL; i++) {
@@ -566,7 +566,7 @@ create_volume(struct tcplay_opts *opts)
 	ehdr = hehdr = NULL;
 	ehdr_backup = hehdr_backup = NULL;
 	ret = -1; /* Default to returning error */
-	
+
 	if (TC_FLAG_SET(opts->flags, VERACRYPT_MODE))
 		veracrypt_mode = 1;
 
@@ -1814,7 +1814,12 @@ dm_setup(const char *mapname, struct tcplay_info *info)
 			goto out;
 		}
 
-		snprintf(uu, 1024, "CRYPT-TCPLAY-%s", uu_temp);
+		if (TC_FLAG_SET(info->flags, VERACRYPT_MODE)){
+			snprintf(uu, 1024, "CRYPT-VCRYPT-%s-%s", uu_temp ,map);
+		} else {
+			snprintf(uu, 1024, "CRYPT-TCRYPT-%s-%s", uu_temp,map);
+		}
+		
 		free(uu_temp);
 
 		if ((dm_task_set_uuid(dmt, uu)) == 0) {
@@ -2051,7 +2056,7 @@ struct pbkdf_prf_algo *
 check_prf_algo(int veracrypt_mode, const char *algo, int quiet)
 {
 	int i, found = 0;
-	struct pbkdf_prf_algo *pbkdf_prf_algos = 
+	struct pbkdf_prf_algo *pbkdf_prf_algos =
 		(veracrypt_mode)? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 
 	for (i = 0; pbkdf_prf_algos[i].name != NULL; i++) {


### PR DESCRIPTION
create entries at "/dev/disk/by-id/" to be in format of "CRYPT-TYPE-UUID-MAPPER_NAME" to be consistent with cryptsetup.

This change will allow cryptsetup managed volumes like LUKS volumes to have the same entry structure as those of tcplay managed volumes.

example"

```
[mtz@ink ~]$ 
[mtz@ink ~]$ 
[mtz@ink ~]$ ls /dev/disk/by-id/ | grep CRYPT
dm-uuid-CRYPT-LUKS1-60709d665a3e41a3b5e6b9b76507eef1-zuluCrypt-500-NAAN-luks_volume.img-4246148314@
dm-uuid-CRYPT-VCRYPT-fda426bd-b576-4e1e-89f7-39bba38e512c-zuluCrypt-500-NAAN-volume.img-2014671880@
[mtz@ink ~]$
```
