### PR TITLE
add an option to create a mapper in read only mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -54,7 +54,7 @@
 #define FLAG_LONG_USE_HDR_FILE	0xfe01
 #define FLAG_LONG_USE_HHDR_FILE	0xfe02
 #define FLAG_LONG_NO_RETRIES	0xfabc
-
+#define FLAG_LONG_READ_ONLY_MODE 0xfe04
 
 static
 void
@@ -74,7 +74,7 @@ usage(void)
 	    "       tcplay -i -d device [--veracrypt-mode] [-e] [-f keyfile_hidden] [-k keyfile]\n"
 	    "              [-s system_device] [--fde] [--use-backup]\n"
 	    "              [--use-hdr-file=hdr_file] [--use-hidden-hdr-file=hdr_file]\n"
-	    "       tcplay -m mapping -d device [--veracrypt-mode] [-e] [-f keyfile_hidden] [-k keyfile]\n"
+	    "       tcplay -m mapping -d device [--read-only] [--veracrypt-mode] [-e] [-f keyfile_hidden] [-k keyfile]\n"
 	    "              [-s system_device] [--fde] [--use-backup] [--allow-trim]\n"
 	    "              [--use-hdr-file=hdr_file] [--use-hidden-hdr-file=hdr_file]\n"
 	    "       tcplay --modify -d device [--veracrypt-mode] [-k keyfile] [--new-keyfile=keyfile]\n"
@@ -170,6 +170,8 @@ usage(void)
 	    "Valid options for --info and --map are:\n"
 	    " -e, --protect-hidden\n"
 	    "\t Protect a hidden volume when mounting the outer volume.\n"
+	    " --read-only\n"
+	    "\t Create mapper in read only mode.\n"
 	    " -s <disk path>, --system-encryption=<disk path>\n"
 	    "\t Specifies that the disk (e.g. /dev/da0) is using system encryption.\n"
 	    " -t, --allow-trim\n"
@@ -236,6 +238,7 @@ static struct option longopts[] = {
 	{ "help",		no_argument,		NULL, 'h' },
 	{ "no-retries",         no_argument,            NULL, FLAG_LONG_NO_RETRIES },
 	{ "veracrypt-mode",     no_argument,            NULL, FLAG_LONG_VERACRYPT_MODE },
+	{ "read-only",          no_argument,            NULL, FLAG_LONG_READ_ONLY_MODE },
 	{ NULL,			0,			NULL, 0   },
 };
 
@@ -427,6 +430,9 @@ main(int argc, char *argv[])
 		case FLAG_LONG_VERACRYPT_MODE:
 			opts->flags |= TC_FLAG_VERACRYPT_MODE;
 			veracrypt_mode = 1;
+			break;
+		case FLAG_LONG_READ_ONLY_MODE:
+			opts->flags |= TC_FLAG_READ_ONLY_MODE;
 			break;
 		case 'h':
 		case '?':

--- a/tcplay.3
+++ b/tcplay.3
@@ -220,6 +220,8 @@ indicates the setting is optional.
 .It Li new_passphrase           Ta           Ta         Ta        Ta          Ta                Ta    "*"    Ta    ""
 .It Li new_keyfiles             Ta           Ta         Ta        Ta          Ta                Ta    "*"    Ta    ""
 .It Li new_prf_algo             Ta           Ta         Ta        Ta          Ta                Ta    "*"    Ta    ""
+.It Li read_only                Ta           Ta         Ta    "*" Ta          Ta                Ta    "*"    Ta    ""
+
 .El
 The varargs accepted by the
 .Fn tc_api_task_set
@@ -254,6 +256,10 @@ the salt.
 The vararg is of type
 .Ft int .
 It determines whether a secure erase is performed as part of the volume creation.
+.It read_only
+The vararg is of type
+.Ft int .
+It determines whether a mapper should be created in read only mode or not.
 .It hidden_size_bytes
 The vararg is of type
 .Ft int64_t .

--- a/tcplay.8
+++ b/tcplay.8
@@ -70,6 +70,7 @@
 .Op Fl s Ar system_device
 .Op Fl t
 .Op Fl -fde
+.Op Fl -read-only
 .Op Fl -use-backup
 .Op Fl -use-hdr-file Ar hdr_file
 .Op Fl -use-hidden-hdr-file Ar hdr_file

--- a/tcplay.c
+++ b/tcplay.c
@@ -464,7 +464,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 	else {
 		veracrypt_mode = 0;
 	}
-
+	
 	if (((TC_FLAG_SET(flags, SYS)) || (TC_FLAG_SET(flags, FDE))) && !hidden_header) {
 		// use only PRF with iterations count for boot encryption
 		// except in case of hidden operating system which uses normal iterations count
@@ -474,7 +474,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 		// use only PRF with iterations count for standard encryption
 		pbkdf_prf_algos = veracrypt_mode? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 	}
-
+	
 	/* Start search for correct algorithm combination */
 	found = 0;
 	for (i = 0; !found && pbkdf_prf_algos[i].name != NULL; i++) {
@@ -566,7 +566,7 @@ create_volume(struct tcplay_opts *opts)
 	ehdr = hehdr = NULL;
 	ehdr_backup = hehdr_backup = NULL;
 	ret = -1; /* Default to returning error */
-
+	
 	if (TC_FLAG_SET(opts->flags, VERACRYPT_MODE))
 		veracrypt_mode = 1;
 
@@ -1814,12 +1814,7 @@ dm_setup(const char *mapname, struct tcplay_info *info)
 			goto out;
 		}
 
-		if (TC_FLAG_SET(info->flags, VERACRYPT_MODE)){
-			snprintf(uu, 1024, "CRYPT-VCRYPT-%s-%s", uu_temp ,map);
-		} else {
-			snprintf(uu, 1024, "CRYPT-TCRYPT-%s-%s", uu_temp,map);
-		}
-		
+		snprintf(uu, 1024, "CRYPT-TCPLAY-%s", uu_temp);
 		free(uu_temp);
 
 		if ((dm_task_set_uuid(dmt, uu)) == 0) {
@@ -2056,7 +2051,7 @@ struct pbkdf_prf_algo *
 check_prf_algo(int veracrypt_mode, const char *algo, int quiet)
 {
 	int i, found = 0;
-	struct pbkdf_prf_algo *pbkdf_prf_algos =
+	struct pbkdf_prf_algo *pbkdf_prf_algos = 
 		(veracrypt_mode)? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 
 	for (i = 0; pbkdf_prf_algos[i].name != NULL; i++) {

--- a/tcplay.c
+++ b/tcplay.c
@@ -464,7 +464,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 	else {
 		veracrypt_mode = 0;
 	}
-	
+
 	if (((TC_FLAG_SET(flags, SYS)) || (TC_FLAG_SET(flags, FDE))) && !hidden_header) {
 		// use only PRF with iterations count for boot encryption
 		// except in case of hidden operating system which uses normal iterations count
@@ -474,7 +474,7 @@ process_hdr(const char *dev, int flags, unsigned char *pass, int passlen,
 		// use only PRF with iterations count for standard encryption
 		pbkdf_prf_algos = veracrypt_mode? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 	}
-	
+
 	/* Start search for correct algorithm combination */
 	found = 0;
 	for (i = 0; !found && pbkdf_prf_algos[i].name != NULL; i++) {
@@ -566,7 +566,7 @@ create_volume(struct tcplay_opts *opts)
 	ehdr = hehdr = NULL;
 	ehdr_backup = hehdr_backup = NULL;
 	ret = -1; /* Default to returning error */
-	
+
 	if (TC_FLAG_SET(opts->flags, VERACRYPT_MODE))
 		veracrypt_mode = 1;
 
@@ -1814,7 +1814,12 @@ dm_setup(const char *mapname, struct tcplay_info *info)
 			goto out;
 		}
 
-		snprintf(uu, 1024, "CRYPT-TCPLAY-%s", uu_temp);
+		if (TC_FLAG_SET(info->flags, VERACRYPT_MODE)){
+			snprintf(uu, 1024, "CRYPT-VCRYPT-%s-%s", uu_temp ,map);
+		} else {
+			snprintf(uu, 1024, "CRYPT-TCRYPT-%s-%s", uu_temp,map);
+		}
+		
 		free(uu_temp);
 
 		if ((dm_task_set_uuid(dmt, uu)) == 0) {
@@ -2051,7 +2056,7 @@ struct pbkdf_prf_algo *
 check_prf_algo(int veracrypt_mode, const char *algo, int quiet)
 {
 	int i, found = 0;
-	struct pbkdf_prf_algo *pbkdf_prf_algos = 
+	struct pbkdf_prf_algo *pbkdf_prf_algos =
 		(veracrypt_mode)? pbkdf_prf_algos_standard_vc : pbkdf_prf_algos_standard_tc;
 
 	for (i = 0; pbkdf_prf_algos[i].name != NULL; i++) {

--- a/tcplay.c
+++ b/tcplay.c
@@ -1826,6 +1826,9 @@ dm_setup(const char *mapname, struct tcplay_info *info)
 
 		free(uu);
 
+		if (TC_FLAG_SET(info->flags, READ_ONLY_MODE))
+			dm_task_set_ro(dmt);
+		
 		if (TC_FLAG_SET(info->flags, FDE)) {
 			/*
 			 * When the full disk encryption (FDE) flag is set,

--- a/tcplay.h
+++ b/tcplay.h
@@ -75,6 +75,7 @@
 #define TC_FLAG_HDR_FROM_FILE	0x0040
 #define TC_FLAG_H_HDR_FROM_FILE	0x0080
 #define TC_FLAG_VERACRYPT_MODE	0x0100
+#define TC_FLAG_READ_ONLY_MODE	0x0200
 
 #define TC_FLAG_SET(f, x)	((f & TC_FLAG_##x) == TC_FLAG_##x)
 

--- a/tcplay_api.c
+++ b/tcplay_api.c
@@ -431,6 +431,12 @@ tc_api_task_set(tc_api_task task, const char *key, ...)
 		opts->state_change_fn = sc_fn;
 		vp = va_arg(ap, void *);
 		opts->api_ctx = vp;
+	} else if (_match(key, "read_only")) {
+		i = va_arg(ap, int);
+		if (i)
+			opts->flags |= TC_FLAG_READ_ONLY_MODE;
+		else
+			opts->flags &= ~TC_FLAG_READ_ONLY_MODE;
 	} else {
 		r = TC_ERR_UNIMPL;
 	}


### PR DESCRIPTION
I reverted the previous commit that attempted to create mapper names in the same format cryptsetup does it and i will revisit it later on.

I do not know how to remove reverse commit and that why it shows up here and i hope you wont it as its just noise with no effect i dont know how to get rid of it.

The purpose of this commit is to add an option to create mapper path in read only mode.
